### PR TITLE
Gettext support

### DIFF
--- a/lib/liberator/content_negotiation.ex
+++ b/lib/liberator/content_negotiation.ex
@@ -2,7 +2,58 @@ defmodule Liberator.ContentNegotiation do
   import Plug.Conn
   @moduledoc false
 
-  def accept_something(conn, key, header_name, available_values, wildcard \\ "*") do
+  def media_type_available?(module, conn) do
+    accept_something(
+      conn,
+      :media_type,
+      "accept",
+      apply(module, :available_media_types, [conn]),
+      "*/*"
+    )
+  end
+
+  def language_available?(module, conn) do
+    assigns =
+      accept_something(
+        conn,
+        :language,
+        "accept-language",
+        apply(module, :available_languages, [conn])
+      )
+    language =
+      if is_map(assigns) do
+        Map.get(assigns, :language)
+      else
+        nil
+      end
+
+    unless is_nil(language) or language == "*" do
+      assigns.language
+      |> String.replace("-", "_")
+      |> Gettext.put_locale()
+    end
+    assigns
+  end
+
+  def charset_available?(module, conn) do
+    accept_something(
+      conn,
+      :charset,
+      "accept-charset",
+      apply(module, :available_charsets, [conn])
+    )
+  end
+
+  def encoding_available?(module, conn) do
+    accept_something(
+      conn,
+      :encoding,
+      "accept-encoding",
+      apply(module, :available_encodings, [conn])
+    )
+  end
+
+  defp accept_something(conn, key, header_name, available_values, wildcard \\ "*") do
     vals =
       get_req_header(conn, header_name)
       |> Enum.flat_map(&String.split(&1, ","))

--- a/lib/liberator/default/content_negotiation.ex
+++ b/lib/liberator/default/content_negotiation.ex
@@ -1,4 +1,4 @@
-defmodule Liberator.ContentNegotiation do
+defmodule Liberator.Default.ContentNegotiation do
   import Plug.Conn
   @moduledoc false
 

--- a/lib/liberator/default/handlers.ex
+++ b/lib/liberator/default/handlers.ex
@@ -1,0 +1,121 @@
+defmodule Liberator.Default.Handlers do
+  import Liberator.Gettext
+
+  @moduledoc false
+
+  def handle_ok(_onn) do
+    gettext("OK")
+  end
+
+  def handle_options(_conn) do
+    gettext("Options")
+  end
+
+  def handle_created(_conn) do
+    gettext("Created")
+  end
+
+  def handle_accepted(_conn) do
+    gettext("Accepted")
+  end
+
+  def handle_no_content(_conn) do
+    gettext("No Content")
+  end
+
+  def handle_multiple_representations(_conn) do
+    gettext("Multiple Representations")
+  end
+
+  def handle_moved_permanently(_conn) do
+    gettext("Moved Permanently")
+  end
+
+  def handle_see_other(_conn) do
+    gettext("See Other")
+  end
+
+  def handle_not_modified(_conn) do
+    gettext("Not Modified")
+  end
+
+  def handle_moved_temporarily(_conn) do
+    gettext("Moved Temporarily")
+  end
+
+  def handle_malformed(_conn) do
+    gettext("Malformed")
+  end
+
+  def handle_payment_required(_conn) do
+    gettext("Payment Required")
+  end
+
+  def handle_unauthorized(_conn) do
+    gettext("Unauthorized")
+  end
+
+  def handle_forbidden(_conn) do
+    gettext("Forbidden")
+  end
+
+  def handle_not_found(_conn) do
+    gettext("Not Found")
+  end
+
+  def handle_method_not_allowed(_conn) do
+    gettext("Method Not Allowed")
+  end
+
+  def handle_not_acceptable(_conn) do
+    gettext("Not Acceptable")
+  end
+
+  def handle_conflict(_conn) do
+    gettext("Conflict")
+  end
+
+  def handle_gone(_conn) do
+    gettext("Gone")
+  end
+
+  def handle_precondition_failed(_conn) do
+    gettext("Precondition Failed")
+  end
+
+  def handle_request_entity_too_large(_conn) do
+    gettext("Request Entity Too Large")
+  end
+
+  def handle_uri_too_long(_conn) do
+    gettext("URI Too Long")
+  end
+
+  def handle_unsupported_media_type(_conn) do
+    gettext("Unsupported Media Type")
+  end
+
+  def handle_unprocessable_entity(_conn) do
+    gettext("Unprocessable Entity")
+  end
+
+  def handle_too_many_requests(_conn) do
+    gettext("Too Many Requests")
+  end
+
+  def handle_unavailable_for_legal_reasons(_conn) do
+    gettext("Unavailable for Legal Reasons")
+  end
+
+  def handle_not_implemented(_conn) do
+    gettext("Not Implemented")
+  end
+
+  def handle_unknown_method(_conn) do
+    gettext("Unknown Method")
+  end
+
+  def handle_service_unavailable(_conn) do
+    gettext("Service Unavailable")
+  end
+end

--- a/lib/liberator/gettext.ex
+++ b/lib/liberator/gettext.ex
@@ -1,0 +1,5 @@
+defmodule Liberator.Gettext do
+  use Gettext, otp_app: :liberator
+
+  @moduledoc false
+end

--- a/lib/liberator/resource.ex
+++ b/lib/liberator/resource.ex
@@ -1359,43 +1359,22 @@ defmodule Liberator.Resource do
 
       @impl true
       def media_type_available?(conn) do
-        Liberator.ContentNegotiation.accept_something(
-          conn,
-          :media_type,
-          "accept",
-          available_media_types(conn),
-          "*/*"
-        )
+        Liberator.ContentNegotiation.media_type_available?(__MODULE__, conn)
       end
 
       @impl true
       def language_available?(conn) do
-        Liberator.ContentNegotiation.accept_something(
-          conn,
-          :language,
-          "accept-language",
-          available_languages(conn)
-        )
+        Liberator.ContentNegotiation.language_available?(__MODULE__, conn)
       end
 
       @impl true
       def charset_available?(conn) do
-        Liberator.ContentNegotiation.accept_something(
-          conn,
-          :charset,
-          "accept-charset",
-          available_charsets(conn)
-        )
+        Liberator.ContentNegotiation.charset_available?(__MODULE__, conn)
       end
 
       @impl true
       def encoding_available?(conn) do
-        Liberator.ContentNegotiation.accept_something(
-          conn,
-          :encoding,
-          "accept-encoding",
-          available_encodings(conn)
-        )
+        Liberator.ContentNegotiation.encoding_available?(__MODULE__, conn)
       end
 
       @impl true
@@ -1558,149 +1537,91 @@ defmodule Liberator.Resource do
       end
 
       @impl true
-      def handle_ok(conn) do
-        "OK"
-      end
+      defdelegate handle_ok(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_options(conn) do
-        "Options"
-      end
+      defdelegate handle_options(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_created(conn) do
-        "Created"
-      end
+      defdelegate handle_created(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_accepted(conn) do
-        "Accepted"
-      end
+      defdelegate handle_accepted(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_no_content(conn) do
-        "No Content"
-      end
+      defdelegate handle_no_content(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_multiple_representations(conn) do
-        "Multiple Representations"
-      end
+      defdelegate handle_multiple_representations(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_moved_permanently(conn) do
-        "Moved Permanently"
-      end
+      defdelegate handle_moved_permanently(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_see_other(conn) do
-        "See Other"
-      end
+      defdelegate handle_see_other(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_not_modified(conn) do
-        "Not Modified"
-      end
+      defdelegate handle_not_modified(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_moved_temporarily(conn) do
-        "Moved Temporarily"
-      end
+      defdelegate handle_moved_temporarily(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_malformed(conn) do
-        "Malformed"
-      end
+      defdelegate handle_malformed(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_payment_required(_conn) do
-        "Payment Required"
-      end
+      defdelegate handle_payment_required(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_unauthorized(conn) do
-        "Unauthorized"
-      end
+      defdelegate handle_unauthorized(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_forbidden(conn) do
-        "Forbidden"
-      end
+      defdelegate handle_forbidden(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_not_found(conn) do
-        "Not Found"
-      end
+      defdelegate handle_not_found(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_method_not_allowed(conn) do
-        "Method Not Allowed"
-      end
+      defdelegate handle_method_not_allowed(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_not_acceptable(conn) do
-        "Not Acceptable"
-      end
+      defdelegate handle_not_acceptable(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_conflict(conn) do
-        "Conflict"
-      end
+      defdelegate handle_conflict(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_gone(conn) do
-        "Gone"
-      end
+      defdelegate handle_gone(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_precondition_failed(conn) do
-        "Precondition Failed"
-      end
+      defdelegate handle_precondition_failed(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_request_entity_too_large(conn) do
-        "Request Entity Too Large"
-      end
+      defdelegate handle_request_entity_too_large(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_uri_too_long(conn) do
-        "URI Too Long"
-      end
+      defdelegate handle_uri_too_long(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_unsupported_media_type(conn) do
-        "Unsupported Media Type"
-      end
+      defdelegate handle_unsupported_media_type(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_unprocessable_entity(conn) do
-        "Unprocessable Entity"
-      end
+      defdelegate handle_unprocessable_entity(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_too_many_requests(conn) do
-        "Too Many Requests"
-      end
+      defdelegate handle_too_many_requests(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_unavailable_for_legal_reasons(_conn) do
-        "Unavailable for Legal Reasons"
-      end
+      defdelegate handle_unavailable_for_legal_reasons(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_not_implemented(conn) do
-        "Not Implemented"
-      end
+      defdelegate handle_not_implemented(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_unknown_method(conn) do
-        "Unknown Method"
-      end
+      defdelegate handle_unknown_method(_conn), to: Liberator.Default.Handlers
 
       @impl true
-      def handle_service_unavailable(conn) do
-        "Service Unavailable"
-      end
+      defdelegate handle_service_unavailable(_conn), to: Liberator.Default.Handlers
 
       defoverridable Liberator.Resource
     end

--- a/lib/liberator/resource.ex
+++ b/lib/liberator/resource.ex
@@ -265,6 +265,21 @@ defmodule Liberator.Resource do
 
   This will add a header called `x-liberator-trace` that will show you the entire set of decisions, in the order they were made.
 
+  ## Internationalization and Localization (i18n and l10n)
+
+  During content negotiation (specifically, in the call to `c:language_available?/1`)
+  the `accept-language` header is inspected, and the `:language` key is added to `conn.assigns`.
+  This callback also sets the `Gettext` locale for the current process to the value it finds, using `Gettext.put_locale/1`.
+  So, in your handler functions, all you need to do is make your usual `gettext` calls.
+  Everything else is handled for you.
+
+      defmodule MyInternationalizedResource do
+        use Liberator.Resource
+
+        def available_languages(_): ["en", "es", "de", "fr"]
+        def handle_ok(_), do: gettext("Hello world!")
+      end
+
   ## Advanced Overrides
 
   Liberator tries to give you access to as much of the program as possible.
@@ -657,7 +672,9 @@ defmodule Liberator.Resource do
   @doc """
   Check if the requested language is available.
 
-  By default, uses the values returned by `c:available_languages/1`.
+  By default, uses the values returned by `c:available_languages/1`,
+  and returns a map with the key `:language` set to the negotiated language,
+  which will be merged into `conn.assigns`.
   """
   @doc since: "1.0"
   @callback language_available?(Plug.Conn.t()) :: true | false
@@ -673,7 +690,9 @@ defmodule Liberator.Resource do
   @doc """
   Check of the requested charset is available.
 
-  By default, uses the values returned by `c:available_charsets/1`.
+  By default, uses the values returned by `c:available_charsets/1`,
+  and returns a map with the key `:charset` set to the negotiated charset,
+  which will be merged into `conn.assigns`.
   """
   @doc since: "1.0"
   @callback charset_available?(Plug.Conn.t()) :: true | false
@@ -689,7 +708,9 @@ defmodule Liberator.Resource do
   @doc """
   Check of the requested encoding is available.
 
-  By default, uses the values returned by `c:available_encodings/1`.
+  By default, uses the values returned by `c:available_encodings/1`,
+  and returns a map with the key `:encoding` set to the negotiated encoding,
+  which will be merged into `conn.assigns`.
   """
   @doc since: "1.0"
   @callback encoding_available?(Plug.Conn.t()) :: true | false

--- a/lib/liberator/resource.ex
+++ b/lib/liberator/resource.ex
@@ -280,6 +280,9 @@ defmodule Liberator.Resource do
         def handle_ok(_), do: gettext("Hello world!")
       end
 
+  All of the default handler messages are internationalized, but we need help with translations!
+  If you can help with this, please submit a pull request on [Liberator's GitHub page](https://github.com/Cantido/liberator)!
+
   ## Advanced Overrides
 
   Liberator tries to give you access to as much of the program as possible.

--- a/lib/liberator/resource.ex
+++ b/lib/liberator/resource.ex
@@ -1359,22 +1359,22 @@ defmodule Liberator.Resource do
 
       @impl true
       def media_type_available?(conn) do
-        Liberator.ContentNegotiation.media_type_available?(__MODULE__, conn)
+        Liberator.Default.ContentNegotiation.media_type_available?(__MODULE__, conn)
       end
 
       @impl true
       def language_available?(conn) do
-        Liberator.ContentNegotiation.language_available?(__MODULE__, conn)
+        Liberator.Default.ContentNegotiation.language_available?(__MODULE__, conn)
       end
 
       @impl true
       def charset_available?(conn) do
-        Liberator.ContentNegotiation.charset_available?(__MODULE__, conn)
+        Liberator.Default.ContentNegotiation.charset_available?(__MODULE__, conn)
       end
 
       @impl true
       def encoding_available?(conn) do
-        Liberator.ContentNegotiation.encoding_available?(__MODULE__, conn)
+        Liberator.Default.ContentNegotiation.encoding_available?(__MODULE__, conn)
       end
 
       @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Liberator.MixProject do
       version: "1.3.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
+      compilers: [:gettext] ++ Mix.compilers,
       deps: deps()
     ]
   end
@@ -65,6 +66,7 @@ defmodule Liberator.MixProject do
   defp deps do
     [
       {:plug_cowboy, "~> 2.0"},
+      {:gettext, "~> 0.18.2"},
       {:jason, "~> 1.2"},
       {:timex, "~> 3.5"},
       {:credo, "~> 1.5.0-rc.2", only: [:dev, :test], runtime: false},

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,156 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here as no
+## effect: edit them in PO (.po) files instead.
+msgid ""
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:19
+msgid "Accepted"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:75
+msgid "Conflict"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:15
+msgid "Created"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:59
+msgid "Forbidden"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:79
+msgid "Gone"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:47
+msgid "Malformed"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:67
+msgid "Method Not Allowed"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:31
+msgid "Moved Permanently"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:43
+msgid "Moved Temporarily"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:27
+msgid "Multiple Representations"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:23
+msgid "No Content"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:71
+msgid "Not Acceptable"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:63
+msgid "Not Found"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:111
+msgid "Not Implemented"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:39
+msgid "Not Modified"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:7
+msgid "OK"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:11
+msgid "Options"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:51
+msgid "Payment Required"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:83
+msgid "Precondition Failed"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:87
+msgid "Request Entity Too Large"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:35
+msgid "See Other"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:119
+msgid "Service Unavailable"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:103
+msgid "Too Many Requests"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:91
+msgid "URI Too Long"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:55
+msgid "Unauthorized"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:107
+msgid "Unavailable for Legal Reasons"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:115
+msgid "Unknown Method"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:99
+msgid "Unprocessable Entity"
+msgstr ""
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:95
+msgid "Unsupported Media Type"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,157 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:19
+msgid "Accepted"
+msgstr "Accepted"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:75
+msgid "Conflict"
+msgstr "Conflict"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:15
+msgid "Created"
+msgstr "Created"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:59
+msgid "Forbidden"
+msgstr "Forbidden"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:79
+msgid "Gone"
+msgstr "Gone"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:47
+msgid "Malformed"
+msgstr "Malformed"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:67
+msgid "Method Not Allowed"
+msgstr "Method Not Allowed"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:31
+msgid "Moved Permanently"
+msgstr "Moved Permanently"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:43
+msgid "Moved Temporarily"
+msgstr "Moved Temporarily"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:27
+msgid "Multiple Representations"
+msgstr "Multiple Representations"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:23
+msgid "No Content"
+msgstr "No Content"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:71
+msgid "Not Acceptable"
+msgstr "Not Acceptable"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:63
+msgid "Not Found"
+msgstr "Not Found"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:111
+msgid "Not Implemented"
+msgstr "Not Implemented"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:39
+msgid "Not Modified"
+msgstr "Not Modified"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:7
+msgid "OK"
+msgstr "OK"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:11
+msgid "Options"
+msgstr "Options"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:51
+msgid "Payment Required"
+msgstr "Payment Required"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:83
+msgid "Precondition Failed"
+msgstr "Precondition Failed"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:87
+msgid "Request Entity Too Large"
+msgstr "Request Entity Too Large"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:35
+msgid "See Other"
+msgstr "See Other"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:119
+msgid "Service Unavailable"
+msgstr "Service Unavailable"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:103
+msgid "Too Many Requests"
+msgstr "Too Many Requests"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:91
+msgid "URI Too Long"
+msgstr "URI Too Long"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:55
+msgid "Unauthorized"
+msgstr "Unauthorized"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:107
+msgid "Unavailable for Legal Reasons"
+msgstr "Unavailable for Legal Reasons"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:115
+msgid "Unknown Method"
+msgstr "Unknown Method"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:99
+msgid "Unprocessable Entity"
+msgstr "Unprocessable Entity"
+
+#, elixir-format
+#: lib/liberator/default/handlers.ex:95
+msgid "Unsupported Media Type"
+msgstr "Unsupported Media Type"


### PR DESCRIPTION
I started doing research for #8, I quickly realized that the de-facto way to internationalize Elixir apps is with [Gettext](https://github.com/elixir-gettext/gettext). It was a little awkward to include into the app, because it's not terribly library-friendly. It needs an OTP app in order to work, but I decided that that's fine for supporting our own default translations. Anyone implementing their own Gettext backend will get their translations going through just fine, and shouldn't interfere with ours.